### PR TITLE
Fix: Today Page Not Updating #126

### DIFF
--- a/js/today.js
+++ b/js/today.js
@@ -17,12 +17,12 @@ const TODAYPAGE_DOM_IDS = {
     daysInTheYearDomElement: 'year-count',
 };
 
-function updateDate() {
+const updateDate = () => {
     let today = new Date();
     setDomElements(today);
-}
+};
 
-function setDomElements(today) {
+const setDomElements = (today) => {
     day = document.getElementById(TODAYPAGE_DOM_IDS.dayOfMonthDomElement);
     month = document.getElementById(TODAYPAGE_DOM_IDS.monthDomElement);
     year = document.getElementById(TODAYPAGE_DOM_IDS.yearDomElement);
@@ -42,7 +42,7 @@ function setDomElements(today) {
     }));
     setInnerHtmlForNotNull(dayCount, dayClock.countDays());
     setInnerHtmlForNotNull(daysInYear, dayClock.getDaysinYear());
-}
+};
 
 const copyDOY = async () => {
     await navigator.clipboard.writeText(`Day ${dayCount.innerText || 'rcountdown'}/365`);

--- a/js/today.js
+++ b/js/today.js
@@ -1,13 +1,13 @@
 import { NewYearClock } from "./clock.js";
 import { setInnerHtmlForNotNull, addWhatappEventHandler } from "./functions.js";
 import { notifyUser } from "./uiFunctions.js";
-const today = new Date();
-const dayClock = new NewYearClock()
+
+const dayClock = new NewYearClock();
 let day, month, year, time, dayOfWeek, dayCount, daysInYear;
 
 const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-const TODAYPAGE_DOM_IDS ={
+const TODAYPAGE_DOM_IDS = {
     yearDomElement: 'year',
     monthDomElement: 'month',
     dayOfMonthDomElement: 'dayOfMonth',
@@ -15,31 +15,31 @@ const TODAYPAGE_DOM_IDS ={
     timeDomElement: 'time',
     dayCountDomElement: 'countDay',
     daysInTheYearDomElement: 'year-count',
+};
+
+function updateDate() {
+    let today = new Date();
+    setDomElements(today);
 }
-const getAndSetDomElements = () => {
-    year = document.getElementById(TODAYPAGE_DOM_IDS.yearDomElement);
-    month = document.getElementById(TODAYPAGE_DOM_IDS.monthDomElement);
+
+function setDomElements(today) {
     day = document.getElementById(TODAYPAGE_DOM_IDS.dayOfMonthDomElement);
+    month = document.getElementById(TODAYPAGE_DOM_IDS.monthDomElement);
+    year = document.getElementById(TODAYPAGE_DOM_IDS.yearDomElement);
     dayOfWeek = document.getElementById(TODAYPAGE_DOM_IDS.dayOfWeekDomElement);
     time = document.getElementById(TODAYPAGE_DOM_IDS.timeDomElement);
     dayCount = document.getElementById(TODAYPAGE_DOM_IDS.dayCountDomElement);
     daysInYear = document.getElementById(TODAYPAGE_DOM_IDS.daysInTheYearDomElement);
 
-    setDomElements();
-}
-
-const setDomElements = () => {
-    //todo: add day count of the year to DOM elements to update
-    setInnerHtmlForNotNull(day, today.getDate())
-    setInnerHtmlForNotNull(month, months[today.getMonth()])
-    setInnerHtmlForNotNull(year, today.getFullYear())
-    setInnerHtmlForNotNull(dayOfWeek, days[today.getDay()])
+    setInnerHtmlForNotNull(day, today.getDate());
+    setInnerHtmlForNotNull(month, months[today.getMonth()]);
+    setInnerHtmlForNotNull(year, today.getFullYear());
+    setInnerHtmlForNotNull(dayOfWeek, days[today.getDay()]);
     setInnerHtmlForNotNull(time, today.toLocaleString("en-US", {
         hour: '2-digit',
         minute: '2-digit',
         hour12: true
-    }))
-    // day count
+    }));
     setInnerHtmlForNotNull(dayCount, dayClock.countDays());
     setInnerHtmlForNotNull(daysInYear, dayClock.getDaysinYear());
 }
@@ -47,19 +47,18 @@ const setDomElements = () => {
 const copyDOY = async () => {
     await navigator.clipboard.writeText(`Day ${dayCount.innerText || 'rcountdown'}/365`);
     notifyUser("Copied to clipboard");
-}
+};
+
 const addClipBoardEventHandler = () => document.querySelector(".copy-link").addEventListener("click", copyDOY);
 
 const updateTimeValues = () => {
-    return setInterval(setDomElements, 1000);
+    return setInterval(updateDate, 1000);
+};
 
-}
 const registerListenersAndUpdate = () => {
     addWhatappEventHandler();
     addClipBoardEventHandler();
     updateTimeValues();
-}
-getAndSetDomElements();
+};
+
 registerListenersAndUpdate();
-
-


### PR DESCRIPTION
The issue was that the DOM elements were being updated every second, but the data they displayed was not changing because it was only being set on page load or reload. To resolve this, I modified the code so that the today variable, which holds the current date and time, is refreshed every second within the setInterval function. This ensures that the data is current when it’s used to update the DOM elements. Additionally, I consolidated the getAndSetDomElements and setDomElements functions into a single setDomElements function to streamline the code. Now, this unified function is called within the setInterval method, which not only simplifies the code but also guarantees that both the data and the DOM elements are updated in sync every second.