### PR TITLE
Hide mail and whatsapp icons

### DIFF
--- a/html/about.html
+++ b/html/about.html
@@ -49,7 +49,7 @@
             </div>
             <div class="details">
                 <div class="details-title">Version</div>
-                <div class="details-info">2.5.1</div>
+                <div class="details-info">2.5.2</div>
             </div>
             <div class="details">
                 <div class="details-title">Credits</div>

--- a/html/about.html
+++ b/html/about.html
@@ -86,20 +86,20 @@
                 <div class="details-title">Feedback</div>
                 <div class="details-info">Reach out to us via the ff channels</div>
                 <div class="sm-container">
-                    <a href="https://wa.me/233561739868?text=Hello Dev">
+                    <!-- <a href="https://wa.me/233561739868?text=Hello Dev">
                         <div class="sm"><i class="fab fa-whatsapp fa-fw"></i></div>
-                    </a>
+                    </a> -->
                     <a href="https://github.com/RDjarbeng/countdown">
                         <div class="sm"><i class="fab fa-github fa-fw"></i></div>
                     </a>
-                    <a href="mailto:rdjarbeng@gmail.com">
+                    <!-- <a href="mailto:rdjarbeng@gmail.com">
                         <div class="sm"><i class="fas fa-envelope fa-fw"></i></div>
-                    </a>
+                    </a> -->
                 </div>
             </div>
 
             <footer class="footer">
-                All Rights Reserved 2022
+                All Rights Reserved 2025
             </footer>
         </section>
     </main>


### PR DESCRIPTION
Current mail and whatsapp contacts on about page are outdated, hide for now.

Also set the 'All Rights Reserved 2024' to 2025.
