### PR TITLE
Fix: sound notification #134

### DIFF
--- a/js/sound/playNotificationSound.js
+++ b/js/sound/playNotificationSound.js
@@ -1,4 +1,16 @@
 export function playNotificationSound() {
-    let song = new Audio("notification3.mp3");
-    song.play();
+    const audioContext = new (window.AudioContext ||
+        window.webkitAudioContext)();
+    fetch("notification3.mp3")
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => audioContext.decodeAudioData(buffer))
+        .then((decodedData) => {
+            const source = audioContext.createBufferSource();
+            source.buffer = decodedData;
+            source.connect(audioContext.destination);
+            source.start(0);
+        })
+        .catch((error) => {
+            console.warn("Audio playback failed:", error);
+        });
 }


### PR DESCRIPTION
When out of focus the tab was not playing the notification sound (even when the timer has elapsed) as most of the browsers restrict audio play when out of focus.

Solution: -

There is an AudioContext object which creates a temporary buffer and decodes audio bits and starts playing the audio even when tab is out of focus.


![Screenshot 2025-01-07 104632](https://github.com/user-attachments/assets/3936279a-b1b3-46af-8f49-88af7795a72c)


