### PR TITLE
Fix: update banner issue fixes #138

### DIFF
--- a/js/serviceWorkerUpdate.js
+++ b/js/serviceWorkerUpdate.js
@@ -2,51 +2,77 @@ import { registerSW } from "virtual:pwa-register";
 import Toastify from "toastify-js";
 import "toastify-js/src/toastify.css";
 
-
-
-// Check for stored update status
-function checkForUpdateToast() {
-    if (localStorage.getItem("sw-update-available") === "true") {
-        showUpdateToast();
-    }
-}
-
-// Function to show the update toast
+//track banner count
+let countBanner = 0;
 function showUpdateToast() {
-    Toastify({
-        text: `
+    countBanner++;
+    //limit banner count to 1
+    if (countBanner <= 1)
+        Toastify({
+            text: `
             <h4>A newer version of this page is available!</h4>
             <br>
             <a class='do-sw-update'>Click this banner to update and reload</a>
             `,
-        escapeMarkup: false,
-        offset: {
-            x: 50, // horizontal axis - can be a number or a string indicating unity. eg: '2em'
-            y: -150, // vertical axis - can be a number or a string indicating unity. eg: '2em'
-        },
-        className: "updateToastify",
-        close: true,
-        gravity: "bottom",
-        duration: -1,
-        onClick() {
-            console.log("Clicking on update to refresh the new service worker");
-            localStorage.removeItem("sw-update-available"); // Clear the flag
-            updateSW(true); // Trigger service worker update
-        },
-    }).showToast();
+            escapeMarkup: false,
+            offset: {
+                x: 50, // horizontal axis - can be a number or a string indicating unity. eg: '2em'
+                y: -150, // vertical axis - can be a number or a string indicating unity. eg: '2em'
+            },
+            className: "updateToastify",
+            close: true,
+            gravity: "bottom",
+            duration: -1,
+            onClick() {
+                console.log(
+                    "Clicking on update to refresh the new service worker"
+                );
+                updateSW(true); // Trigger service worker update
+            },
+        }).showToast();
 }
 
 // Register the service workers
 const updateSW = registerSW({
     onNeedRefresh() {
         console.log("New app version, now available");
-        localStorage.setItem("sw-update-available", "true"); 
-        showUpdateToast(); 
     },
     onOfflineReady() {
         console.log("App is offline now");
     },
 });
 
-// Check for the update flag on page load
-checkForUpdateToast();
+//check for waiting service worker updates
+async function checkWaitingServiceWorker() {
+    if ("serviceWorker" in navigator) {
+        const registration = await navigator.serviceWorker.ready;
+        if (registration.waiting) {
+            console.log("A new Service Worker is waiting");
+            showUpdateToast();
+        }
+    }
+}
+
+if ("serviceWorker" in navigator) {
+    // Initial check on page load
+    checkWaitingServiceWorker();
+
+    // Listen for new service worker taking control
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+        console.log("New service worker activated");
+        checkWaitingServiceWorker();
+    });
+
+    // Listen for new updates
+    navigator.serviceWorker.ready.then((registration) => {
+        registration.addEventListener("updatefound", () => {
+            console.log("New service worker found");
+            const newWorker = registration.installing;
+            newWorker.addEventListener("statechange", () => {
+                if (newWorker.state === "installed") {
+                    checkWaitingServiceWorker();
+                }
+            });
+        });
+    });
+}

--- a/js/serviceWorkerUpdate.js
+++ b/js/serviceWorkerUpdate.js
@@ -2,34 +2,51 @@ import { registerSW } from "virtual:pwa-register";
 import Toastify from "toastify-js";
 import "toastify-js/src/toastify.css";
 
-//add service worker update functionality
-//service worker update and offline functionality
+
+
+// Check for stored update status
+function checkForUpdateToast() {
+    if (localStorage.getItem("sw-update-available") === "true") {
+        showUpdateToast();
+    }
+}
+
+// Function to show the update toast
+function showUpdateToast() {
+    Toastify({
+        text: `
+            <h4>A newer version of this page is available!</h4>
+            <br>
+            <a class='do-sw-update'>Click this banner to update and reload</a>
+            `,
+        escapeMarkup: false,
+        offset: {
+            x: 50, // horizontal axis - can be a number or a string indicating unity. eg: '2em'
+            y: -150, // vertical axis - can be a number or a string indicating unity. eg: '2em'
+        },
+        className: "updateToastify",
+        close: true,
+        gravity: "bottom",
+        duration: -1,
+        onClick() {
+            console.log("Clicking on update to refresh the new service worker");
+            localStorage.removeItem("sw-update-available"); // Clear the flag
+            updateSW(true); // Trigger service worker update
+        },
+    }).showToast();
+}
+
+// Register the service workers
 const updateSW = registerSW({
     onNeedRefresh() {
-        console.log("Update sw, now available, Rcountdown");
-        Toastify({
-            text: `
-                <h4>A newer version of this page is available!</h4>
-                <br>
-                <a class='do-sw-update'>Click this banner to update and reload</a>
-                `,
-            escapeMarkup: false,
-            offset: {
-                x: 50, // horizontal axis - can be a number or a string indicating unity. eg: '2em'
-                y: -150, // vertical axis - can be a number or a string indicating unity. eg: '2em'
-            },
-            // selector: 'testToast',
-            className: "updateToastify",
-            close: true,
-            gravity: "bottom",
-            duration: -1,
-            onClick() {
-                console.log("Clicking on update to refresh the new service worker");
-                updateSW(true);
-            },
-        }).showToast();
+        console.log("New app version, now available");
+        localStorage.setItem("sw-update-available", "true"); 
+        showUpdateToast(); 
     },
     onOfflineReady() {
         console.log("App is offline now");
     },
 });
+
+// Check for the update flag on page load
+checkForUpdateToast();


### PR DESCRIPTION
The register service worker logic only runs once when we land on home page.
So, whenever there's a new update and land on home page, we see the update banner(toast) as the register logic has been re initialized.
When we navigate to other pages, the page does not run the register logic again in the same lifecycle context as the home page. As a result, the toast is not shown.

Fix:
Used localStorage (which acts as a global context for all the pages) to store a flag. When the flag is true, we show the banner and when we have clicked the toast and updated the app, the flag is removed.