### PR TITLE
feat: enable notifications on other pages #143

### DIFF
--- a/html/about.html
+++ b/html/about.html
@@ -103,6 +103,7 @@
             </footer>
         </section>
     </main>
+    <script src="/js/customInitializeTimers.js" async type="module"></script>
     <script src="/js/error.js" type="module"></script>
     <script src="/js/loadCustomUI.js" type="module"></script>
     <script src="/js/sidebar.js" async type="module"></script>

--- a/html/about.html
+++ b/html/about.html
@@ -103,8 +103,8 @@
             </footer>
         </section>
     </main>
-    <script src="/js/customInitializeTimers.js" async type="module"></script>
     <script src="/js/error.js" type="module"></script>
+    <script src="/js/customInitializeTimers.js" async type="module"></script>
     <script src="/js/loadCustomUI.js" type="module"></script>
     <script src="/js/sidebar.js" async type="module"></script>
     <script src="/js/serviceWorkerUpdate.js" type="module"></script>

--- a/html/today.html
+++ b/html/today.html
@@ -59,8 +59,8 @@
             </div>
         </section>
     </main>
-    <script src="/js/customInitializeTimers.js" async type="module"></script>
     <script src="/js/error.js" type="module"></script>
+    <script src="/js/customInitializeTimers.js" async type="module"></script>
      <!-- <script src="/app.js" type="module"></script>  -->
     <script src="/js/sidebar.js" type="module" async></script>
     <script src="/js/loadCustomUI.js" type="module"></script>

--- a/html/today.html
+++ b/html/today.html
@@ -59,8 +59,9 @@
             </div>
         </section>
     </main>
+    <script src="/js/customInitializeTimers.js" async type="module"></script>
     <script src="/js/error.js" type="module"></script>
-    <!-- <script src="/app.js" type="module"></script> -->
+     <!-- <script src="/app.js" type="module"></script>  -->
     <script src="/js/sidebar.js" type="module" async></script>
     <script src="/js/loadCustomUI.js" type="module"></script>
     <script src="/js/today.js" type="module"></script>

--- a/js/customInitializeTimers.js
+++ b/js/customInitializeTimers.js
@@ -1,0 +1,56 @@
+import { Clock, Anniversary } from "./clock";
+import { fireElapsedEvent } from "./events";
+import { countHasElapsedListener } from "./listpage/listEventListener";
+
+addEventListener("elapsed", countHasElapsedListener);
+
+// Fetch the stored countdown object
+const countdownObject = JSON.parse(localStorage.getItem("mainClock"));
+const isRepeat = countdownObject.repeat;
+
+// Create the appropriate clock instance
+let clock = isRepeat
+    ? new Anniversary(new Date(countdownObject.date))
+    : new Clock(new Date(countdownObject.date));
+
+// Start the countdown
+function updateClock() {
+    // Check if time has elapsed before countdown
+    if (clock.getDistance() <= 0) {
+        console.log("Time elapsed, handling completion...");
+
+        // Fire the event for the current completion
+        fireElapsedEvent(countdownObject.text);
+
+        if (isRepeat) {
+            // For Anniversary clock, reset to next occurrence
+            clock.resetMethod();
+            console.log(`Reset to next occurrence: ${clock.endDate}`);
+
+            // Only continue if we successfully reset to a future date
+            if (clock.getDistance() > 0) {
+                setTimeout(updateClock, 1000);
+            }
+        }
+        return;
+    }
+
+    // Normal countdown flow
+    clock.countDown();
+    console.log(`Time remaining: ${clock.getDistance()} ms`);
+
+    // Schedule next update
+    setTimeout(updateClock, 1000);
+}
+
+
+
+// Initial check and start
+if (clock.getDistance() <= 0 && isRepeat) {
+    // If we're already past the date and it's repeating,
+    // reset to next occurrence before starting
+    clock.resetMethod();
+}
+
+if(clock.getDistance()>=0)
+updateClock();

--- a/js/listpage/listEventListener.js
+++ b/js/listpage/listEventListener.js
@@ -46,7 +46,7 @@ import { showClockRow } from "./list_ui/updateListpageClockAndText.js";
  * Determines the response when a countdown elapses
  * @param {Event} e Ideally contains countdown title at property detail with 
  */
-const countHasElapsedListener =(e)=>{
+export const countHasElapsedListener =(e)=>{
     console.log('Elapsed event fired',e)
     const countdownText = e.detail;
     // errorHandler(countdownText);


### PR DESCRIPTION
Added a custom script for the notifications to load on about and today page.
Now whatever timer is set for main clock, the respective elapsed notification will be shown irrespective of the page the user is on (home, countdown list, today, about)