### PR TITLE
fix error that shows up when there isn't a main countdown on today page

### DIFF
--- a/js/customInitializeTimers.js
+++ b/js/customInitializeTimers.js
@@ -2,10 +2,12 @@ import { Clock, Anniversary } from "./clock";
 import { fireElapsedEvent } from "./events";
 import { countHasElapsedListener } from "./listpage/listEventListener";
 
-addEventListener("elapsed", countHasElapsedListener);
 
 // Fetch the stored countdown object
 const countdownObject = JSON.parse(localStorage.getItem("mainClock"));
+
+if (countdownObject){
+addEventListener("elapsed", countHasElapsedListener);
 const isRepeat = countdownObject.repeat;
 
 // Create the appropriate clock instance
@@ -54,3 +56,4 @@ if (clock.getDistance() <= 0 && isRepeat) {
 
 if(clock.getDistance()>=0)
 updateClock();
+}


### PR DESCRIPTION
When there isn't a main countdown set by the user, example if the user is new and goes immediately to the today page this error shows up.

Caused by referencing properties of countdownObject without checking if it's null.

This PR is to fix this